### PR TITLE
Add native file picker for backup import on mobile

### DIFF
--- a/src/pages/settings/Backup.tsx
+++ b/src/pages/settings/Backup.tsx
@@ -118,8 +118,11 @@ const BackupSettings = () => {
 
       // Prefer base64 data provided by the plugin (safe for small JSON backups)
       if (file.data) {
-        // Decode Base64 to string (backups are UTF-8/ASCII JSON)
-        const text = atob(file.data);
+        // Decode Base64 to UTF-8 string to preserve emojis and non-ASCII
+        const binary = atob(file.data);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+        const text = new TextDecoder("utf-8").decode(bytes);
         importData(text);
         await Toast.show({ text: "Backup importado" });
         return;


### PR DESCRIPTION
Introduces support for importing backups using the native file picker via @capawesome/capacitor-file-picker when running on a native platform. Falls back to the standard file input on web. Handles permissions and error cases for a smoother user experience on Android and iOS.
<img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/82ff78bb-96fc-4cfe-bbe9-1592ed605174" />
