### PR TITLE
Add data reset feature with confirmation dialog

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -10,6 +10,7 @@ android {
 apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
+    implementation project(':capacitor-dialog')
     implementation project(':capacitor-filesystem')
     implementation project(':capacitor-privacy-screen')
     implementation project(':capacitor-share')

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -5,6 +5,9 @@ project(':capacitor-android').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-app'
 project(':capacitor-app').projectDir = new File('../node_modules/@capacitor/app/android')
 
+include ':capacitor-dialog'
+project(':capacitor-dialog').projectDir = new File('../node_modules/@capacitor/dialog/android')
+
 include ':capacitor-filesystem'
 project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/app": "^7.0.2",
         "@capacitor/cli": "^7.4.2",
         "@capacitor/core": "^7.4.2",
+        "@capacitor/dialog": "^7.0.2",
         "@capacitor/filesystem": "^7.1.4",
         "@capacitor/privacy-screen": "^1.1.0",
         "@capacitor/share": "^7.0.2",
@@ -223,6 +224,14 @@
       "integrity": "sha512-akCf9A1FUR8AWTtmgGjHEq6LmGsjA2U7igaJ9PxiCBfyxKqlDbuGHrlNdpvHEjV5tUPH3KYtkze6gtFcNKPU9A==",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/dialog": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/dialog/-/dialog-7.0.2.tgz",
+      "integrity": "sha512-2lRMKEdBV/2LMCwHbC5a03jiU4tdlIN4hXAqmQMxnaa7CAVLfk/vEE+vxA5mpnI/pzoXF/QDQEUXJUd10hbcKA==",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/filesystem": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@capacitor/app": "^7.0.2",
     "@capacitor/cli": "^7.4.2",
     "@capacitor/core": "^7.4.2",
+    "@capacitor/dialog": "^7.0.2",
     "@capacitor/filesystem": "^7.1.4",
     "@capacitor/privacy-screen": "^1.1.0",
     "@capacitor/share": "^7.0.2",

--- a/src/pages/settings/Backup.tsx
+++ b/src/pages/settings/Backup.tsx
@@ -7,10 +7,11 @@ import { Filesystem, Directory, Encoding } from "@capacitor/filesystem";
 import { Capacitor } from "@capacitor/core";
 import { Toast } from "@capacitor/toast";
 import { Share } from "@capacitor/share";
+import { Dialog } from "@capacitor/dialog";
 import { FilePicker } from "@capawesome/capacitor-file-picker";
 
 const BackupSettings = () => {
-  const { exportData, importData } = useFinance();
+  const { exportData, importData, resetAllData } = useFinance();
 
   const download = async () => {
     const data = exportData();
@@ -189,6 +190,36 @@ const BackupSettings = () => {
               />
             )}
           </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Eliminar datos</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Borra permanentemente tus cuentas, categorías, transacciones, recurrentes y créditos. Esta acción no se puede deshacer.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Button
+            variant="destructive"
+            className="w-full"
+            onClick={async () => {
+              const { value } = await Dialog.confirm({
+                title: "Confirmar eliminación",
+                message: "¿Seguro que deseas eliminar todos tus datos financieros? Esta acción no se puede deshacer.",
+                okButtonTitle: "OK",
+                cancelButtonTitle: "Cancelar",
+              });
+              if (value) {
+                resetAllData();
+                try {
+                  await Toast.show({ text: "Datos eliminados" });
+                } catch (_) {}
+              }
+            }}
+          >
+            Eliminar datos
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/src/store/finance.ts
+++ b/src/store/finance.ts
@@ -140,6 +140,7 @@ interface FinanceState {
   // Import / Export
   exportData: () => string;
   importData: (json: string) => void;
+  resetAllData: () => void;
 }
 
 const defaultAccounts: Account[] = [
@@ -455,6 +456,16 @@ export const useFinance = create<FinanceState>()(
         } catch (e) {
           console.error("Import error", e);
         }
+      },
+      resetAllData: () => {
+        set(() => ({
+          accounts: defaultAccounts,
+          categories: defaultCategories,
+          transactions: [],
+          macroGroups: [],
+          recurrings: [],
+          credits: [],
+        }));
       },
     }),
     { name: "finance-store" }


### PR DESCRIPTION
Introduces a destructive action in Backup settings to permanently delete all financial data, including accounts, categories, transactions, recurrings, and credits. Adds @capacitor/dialog as a dependency and integrates a confirmation dialog before data deletion. Implements resetAllData in the finance store to handle the reset logic.
![Screenshot_20250830_173400_Biyuyo](https://github.com/user-attachments/assets/a00cec94-5c9a-47dd-890e-e3998cc0211e)
